### PR TITLE
Fix url generator request argument error

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\URL;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -11,7 +13,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        // Ensure a request instance exists when running in console so services
+        // that depend on the current request (e.g. URL generator) can resolve.
+        if ($this->app->runningInConsole() && ! $this->app->bound('request')) {
+            $this->app->instance('request', Request::create(
+                config('app.url', 'http://127.0.0.1:8000'),
+                'GET'
+            ));
+        }
     }
 
     /**
@@ -19,6 +28,15 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        // Avoid URL operations during console execution where no HTTP request exists.
+        if ($this->app->runningInConsole()) {
+            return;
+        }
+
+        // If your app URL is HTTPS, force scheme to avoid mixed content.
+        $appUrl = (string) config('app.url');
+        if ($appUrl !== '' && str_starts_with($appUrl, 'https://')) {
+            URL::forceScheme('https');
+        }
     }
 }


### PR DESCRIPTION
Bind a dummy `Request` for console commands and guard URL operations in `AppServiceProvider` to fix `UrlGenerator` errors during `php artisan serve`.

The `UrlGenerator` expects a `Request` instance, which is `null` when running console commands like `php artisan serve`. This change ensures a basic `Request` is available in console environments and prevents HTTP-specific URL manipulations from running when no HTTP request exists.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f8546ec-b4af-495b-838e-ff8048ac83f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f8546ec-b4af-495b-838e-ff8048ac83f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

